### PR TITLE
Fix to exit cleanly

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -103,7 +103,7 @@ namespace psedit
                         new MenuItem ("_Quit", "", () => {
                             try
                             {
-                                Application.Shutdown();
+                                Application.RequestStop();
                             }
                             catch {}
                         }, shortcut: Key.CtrlMask | Key.Q)
@@ -161,6 +161,7 @@ namespace psedit
             try
             {
                 Application.Run();
+                Application.Shutdown();
             }
             catch { }
             finally


### PR DESCRIPTION
Without `RequestStop()`, TerminalGui leaves the console in an unclean state with reading the mouse