### PR TITLE
Define `psedit` alias and make `Path` positional

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -10,6 +10,7 @@ using Terminal.Gui;
 namespace psedit
 {
     [Cmdlet("Show", "PSEditor")]
+    [Alias("psedit")]
     public class ShowEdtiorCommand : PSCmdlet
     {
         private PowerShellEditorTextView textEditor;
@@ -20,8 +21,9 @@ namespace psedit
         private Toplevel top;
         private Runspace _runspace;
 
-        [Parameter(ParameterSetName = "Path", ValueFromPipeline = true)]
+        [Parameter(ParameterSetName = "Path", ValueFromPipeline = true, Position = 0)]
         public string Path { get; set; }
+
         [Parameter()]
         public SwitchParameter DisableFormatOnSave { get; set; }
 

--- a/psedit.psd1
+++ b/psedit.psd1
@@ -78,7 +78,7 @@
     # VariablesToExport = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    # AliasesToExport   = '*'
+    AliasesToExport   = 'psedit'
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()


### PR DESCRIPTION
Seems natural to have `psedit` as alias to `Show-PSeditor` and make `Path` positional so you can just do `psedit ./README.md`