### PR TITLE
clear suggestions on blank words and lines

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -363,11 +363,11 @@ namespace psedit
                     offset += host.Runes[lineOffset].Count + Environment.NewLine.Length;
                 }
             }
-
             var text = host.Text.ToString();
 
-            if (text.Length == 0 || offset == 0)
+            if (text.Length == 0 || offset == 0  || host.CurrentColumn == 0)
             {
+                ClearSuggestions();
                 return;
             }
 
@@ -383,7 +383,14 @@ namespace psedit
                 if (_suggestions != null)
                 {
                     var word = GetCurrentWord();
-                    Suggestions = _suggestions.Where(m => m.StartsWith(word, StringComparison.OrdinalIgnoreCase)).ToList().AsReadOnly();
+                    if (!System.String.IsNullOrEmpty(word))
+                    {
+                        Suggestions = _suggestions.Where(m => m.StartsWith(word, StringComparison.OrdinalIgnoreCase)).ToList().AsReadOnly();
+                    }
+                    else 
+                    {
+                        ClearSuggestions();
+                    }
                 }
 
                 return;


### PR DESCRIPTION
We are never calling ClearSuggestions() when the viewed suggestions are no longer valid, and this causes it to linger around in the GUI even if we move to next word, or to the next line

This PR calls ClearSuggestion() when the current column is 0, or the word is blank (since we cant give a reliable suggestion at this point anyways)

This aims to fix #9 