### PR TITLE
Only report unique syntax errors, and fix column number

### DIFF
--- a/Editor/SyntaxErrorDialog.cs
+++ b/Editor/SyntaxErrorDialog.cs
@@ -20,7 +20,7 @@ namespace psedit
 
             foreach (var error in errors)
             {
-                dataTable.Rows.Add(error.Extent.StartLineNumber, error.Extent.EndLineNumber, error.Message);
+                dataTable.Rows.Add(error.Extent.StartLineNumber, error.Extent.StartColumnNumber, error.Message);
 
             }
 

--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -45,7 +45,18 @@ namespace psedit
             }
             else if (hasError)
             {
-                Errors.TryAdd(new Point(column, line), error);
+                // Verify if error has already been reported
+                var foundError = Errors.Where( err => 
+                                                error.Extent.StartColumnNumber == err.Value.Extent.StartColumnNumber &&
+                                                error.Extent.EndColumnNumber == err.Value.Extent.EndColumnNumber &&
+                                                error.Extent.StartLineNumber == err.Value.Extent.StartLineNumber &&
+                                                error.Extent.EndLineNumber == err.Value.Extent.EndLineNumber);
+
+                if (!foundError.Any())
+                {
+                    Errors.TryAdd(new Point(column, line), error);
+                }
+
                 background = Color.Red;
             }
 


### PR DESCRIPTION
Syntax errors are reported once for each character in the part containing the  error, and the "Column" value is not showing the accurate column where the error starts

![image](https://user-images.githubusercontent.com/18571127/204152971-c3e88506-96b4-40ff-ad68-7226b22db4c5.png)


This fix adds to the Errors variable only when the specific error is not already added, and now reflects the actual Column where the syntax error starts
![image](https://user-images.githubusercontent.com/18571127/204153500-b40f28a3-8f78-41b9-b754-71a15d6cc85d.png)

