### PR TITLE
exclude newlines from token matching

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -29,7 +29,8 @@ namespace psedit
                 m.Extent.StartLineNumber <= (line + 1) &&
                 m.Extent.EndLineNumber >= (line + 1) &&
                 m.Extent.StartColumnNumber <= (column + 1) &&
-                m.Extent.EndColumnNumber >= (column + 1));
+                m.Extent.EndColumnNumber >= (column + 1) &&
+                m.Kind != TokenKind.NewLine);
 
             var error = _errors?.FirstOrDefault(m => m.Extent.StartLineNumber <= (line + 1) &&
                 m.Extent.EndLineNumber >= (line + 1) &&


### PR DESCRIPTION
There is some weird coloring behavior whenever you have more than one newline
![image](https://user-images.githubusercontent.com/18571127/204353331-60d36f5f-e103-4425-bdbe-5eeac3975cfb.png)

As far as I can tell, it's because we end up falsely matching against the newline token from powershell parser when coloring the first character after multiple newlines

A simple way to solve this is just to skip matching on newline tokens, since we don't need to color these, then the linq match correctly matches the token we should be coloring for

![image](https://user-images.githubusercontent.com/18571127/204353105-8832e824-128b-4c93-bfbd-83c8595b86a5.png)


