### PR TITLE
Refactor of token syntax highlighting

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -149,8 +149,12 @@ namespace psedit
 
                 // identify token for specific row
                 var rowTokens = tokens.Where(m =>
+                    // single line token
                     m.Extent.StartLineNumber == (idxRow + 1) ||
-                    m.Extent.EndLineNumber >= (idxRow + 1));
+                    // multiline token
+                    (m.Extent.EndLineNumber >= (idxRow + 1) &&
+                        m.Extent.StartLineNumber <= (idxRow + 1)
+                    ));
                 
                 var rowErrors = _errors?.Where(m => 
                     m.Extent.StartLineNumber == (idxRow + 1));
@@ -166,9 +170,17 @@ namespace psedit
 
                     // get token, note that we must provide +1 for the end column, as Start will be 1 and End will be 2 for the example: A
                     var colToken = rowTokens.FirstOrDefault(m =>
-                        (m.Extent.StartColumnNumber <= (tokenCol) &&
-                        m.Extent.EndColumnNumber >= (tokenCol + 1)) &&
-                        m.Kind != TokenKind.NewLine);
+                        // single line token
+                        (((m.Extent.StartColumnNumber <= (tokenCol) &&
+                        m.Extent.EndColumnNumber >= (tokenCol + 1) &&
+                        m.Extent.StartLineNumber == (idxRow + 1))) ||
+                        // multiline token
+                        (m.Extent.EndLineNumber >= (idxRow + 1) &&
+                            m.Extent.StartLineNumber <= (idxRow + 1) &&
+                            m.Extent.StartLineNumber != (idxRow + 1))) &&
+                        m.Kind != TokenKind.NewLine
+                        );
+
 
                     // get any errors
                     var colError = rowErrors?.FirstOrDefault(m =>


### PR DESCRIPTION
I had a look at the syntax highlighting and its a bit of a mess since the parser has one line count, while the rows in the file might be a different one..

These changes solves the matching for single line tokens, but it's still not 100% matching for multiline tokens, the code changes done here makes that easier to solve at least :-) If it encounters a multiline now, it might look weird but it doesn't affect the subsequent syntax highlighting like today

To support multiline, we need to take the StartLineNumber / EndLineNumber into consideration when matching the rows, since chars can be on Line 2, while Start / end of the token is 1 / 3, so then we cant rely on the StartColumnNumber / EndColumnNumber as they refer to the position on line 1 / 3

Tokens that might be multiline are comment blocks, here strings etc..

This also solves #16 

This commit -> Latest version
![image](https://user-images.githubusercontent.com/18571127/205509267-a3a77cc5-f0a5-42cf-9bf4-0bf93899848d.png)

* Moved coloring of tokens to separate function, and also expanded with more colors (to make it easier to see whats working or not) This will also it make easier to support themes etc. 

* Moved token identification from col char to be matched per row, and then col. This makes matching the tokens easier, and greatly improved the experience on large files while navigating (since we currently redraw everything every time you move the cursor)

* Fixed single line token syntax highlighting, previously this was mismatching tokens, causing weird coloring. I believe the main cause for this was incorrect col calculations for tabs
