### PR TITLE
Reference specific version of Nstack for Terminal.Gui

### DIFF
--- a/psedit.csproj
+++ b/psedit.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Nstack.Core" Version="1.0.*" />
+      <PackageReference Include="Nstack.Core" Version="1.0.5" />
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
       <PackageReference Include="Terminal.Gui" Version="1.7.*" />
   </ItemGroup>


### PR DESCRIPTION
There was an update to Nstack to version 1.0.7, but we seem to have some dependency on version 1.0.5 as running on the newer version breaks the application


This solves #20