### PR TITLE
Fix horizontal token matching

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -159,7 +159,7 @@ namespace psedit
                 var rowErrors = _errors?.Where(m => 
                     m.Extent.StartLineNumber == (idxRow + 1));
 
-                var tokenCol = 1;
+                var tokenCol = 1 + LeftColumn;
 
                 Move(0, row);
                 for (int idxCol = LeftColumn; idxCol < lineRuneCount; idxCol++)


### PR DESCRIPTION
Figured out why token matching was off when doing horizontal scrolling, it should work now as well :-)

![HorizontalScroll2](https://user-images.githubusercontent.com/18571127/220690639-1074b3f9-343a-4d69-8f9d-0f96458a7fb4.gif)
