### PR TITLE
Improve Redraw() performance on large files

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -105,18 +105,6 @@ namespace psedit
             }
             else if (hasError)
             {
-                // Verify if error has already been reported
-                var foundError = Errors.Where( err => 
-                                                error.Extent.StartColumnNumber == err.Value.Extent.StartColumnNumber &&
-                                                error.Extent.EndColumnNumber == err.Value.Extent.EndColumnNumber &&
-                                                error.Extent.StartLineNumber == err.Value.Extent.StartLineNumber &&
-                                                error.Extent.EndLineNumber == err.Value.Extent.EndLineNumber);
-
-                if (!foundError.Any())
-                {
-                    Errors.TryAdd(new Point(column, line), error);
-                }
-
                 background = Color.Red;
             }
             
@@ -134,7 +122,20 @@ namespace psedit
             Errors.Clear();
             _errors = errors;
             Runes = StringToRunes(text);
+            foreach (var error in _errors) 
+            {
+                // Verify if error has already been reported
+                var foundError = Errors.Where( err => 
+                                                error.Extent.StartColumnNumber == err.Value.Extent.StartColumnNumber &&
+                                                error.Extent.EndColumnNumber == err.Value.Extent.EndColumnNumber &&
+                                                error.Extent.StartLineNumber == err.Value.Extent.StartLineNumber &&
+                                                error.Extent.EndLineNumber == err.Value.Extent.EndLineNumber);
 
+                if (!foundError.Any())
+                {
+                    Errors.TryAdd(new Point(error.Extent.StartColumnNumber, error.Extent.StartLineNumber), error);
+                }
+            }
             ColorNormal();
 
             var offB = OffSetBackground();

--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -143,6 +143,10 @@ namespace psedit
             var row = 0;
             for (int idxRow = TopRow; idxRow < Runes.Count; idxRow++)
             {
+                if (row > bottom)
+                {
+                    break;
+                }
                 var line = GetLine(Runes, idxRow);
                 int lineRuneCount = line.Count;
                 var col = 0;


### PR DESCRIPTION
I noticed that performance with Redraw() was really bad when opening a 2000-3000 line long Powershell file

![image](https://user-images.githubusercontent.com/18571127/220707381-749cfdcc-fdde-4494-ae4e-d97af2e8b5a5.png)

I did some profiling and found that most time is spent on matching tokens

This fix makes the token matching / adding runes only run for the rows being displayed, as it currently processes all rows (including those that are not being displayed)

![image](https://user-images.githubusercontent.com/18571127/220707473-76a16cb0-6108-4749-9772-214978b5ef99.png)

I'm sure we can optimize further but this is a start  :-)
