### PR TITLE
Fix cancel button in Open / Save dialog

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -75,7 +75,7 @@ namespace psedit
 
                             Application.Run(dialog);
 
-                            if (dialog.FilePath.IsEmpty)
+                            if (dialog.FilePath.IsEmpty || dialog.Canceled == true)
                             {
                                 return;
                             }
@@ -367,8 +367,10 @@ namespace psedit
                 dialog.AllowedFileTypes = new string[] { ".ps1" };
                 Application.Run(dialog);
 
-                if (dialog.FilePath.IsEmpty || Directory.Exists(dialog.FilePath.ToString())) return;
-
+                if (dialog.FilePath.IsEmpty || dialog.Canceled == true || Directory.Exists(dialog.FilePath.ToString()))
+                {
+                    return;
+                }
                 Path = dialog.FilePath.ToString();
                 fileNameStatus.Title = Path;
             }


### PR DESCRIPTION
Currently we don't evaluate whether or not the cancel button has been clicked, so if you select a file and then press cancel, then it will open or save it depending on the dialog open