### PR TITLE
Set back cursor and row after calling Format()

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -190,10 +190,14 @@ namespace psedit
                 var formatValue = textEditor.Text.ToString();
                 if (!System.String.IsNullOrEmpty(formatValue))
                 {
+                    var previousCursorPosition = textEditor.CursorPosition;
+                    var previousTopRow = textEditor.TopRow;
                     var formatted = InvokeCommand.InvokeScript("Invoke-Formatter -ScriptDefinition $args[0]", formatValue).FirstOrDefault();
                     if (formatted != null)
                     {
                         textEditor.Text = formatted.BaseObject as string;
+                        textEditor.CursorPosition = previousCursorPosition;
+                        textEditor.TopRow = previousTopRow;
                     }
                 }
             }


### PR DESCRIPTION
I noticed that the cursor and row position is reset when you press Format, this commit sets the toprow and cursor position back after formatting

This also makes sure we go back to the same row/column when you call Save, since it calls Format()