### PR TITLE
fix Format() on Powershell 5.1

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -190,10 +190,16 @@ namespace psedit
                 var formatValue = textEditor.Text.ToString();
                 if (!System.String.IsNullOrEmpty(formatValue))
                 {
-                    var formatted = InvokeCommand.InvokeScript("Invoke-Formatter -ScriptDefinition $args[0]", formatValue).FirstOrDefault();
-                    if (formatted != null)
+                    using (var powerShell = PowerShell.Create(RunspaceMode.CurrentRunspace))
                     {
-                        textEditor.Text = formatted.BaseObject as string;
+                        powerShell.AddCommand("Invoke-Formatter");
+                        powerShell.AddParameter("ScriptDefinition", formatValue);
+                        var result = powerShell.Invoke();
+                        var formatted = result.FirstOrDefault();
+                        if (formatted != null)
+                        {
+                            textEditor.Text = formatted.BaseObject as string;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a fix for Format() where it's currently failing on PowerShell 5.1, I came across the same error as described in #17, but while testing I could not reproduce it in PowerShell 7, and with PowerShell 5.1 it always threw an exception... Not exactly sure what's going on but it's unable to read the value from the arguments

![image](https://user-images.githubusercontent.com/18571127/221372434-46747544-9129-427e-b3b8-e0230adf6121.png)


I updated it to use the same approach as we do for running scripts, as this works fine on both PowerShell 5.1 and 7