### PR TITLE
fix so error show again in status bar

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -14,6 +14,7 @@ namespace psedit
     public class PowerShellEditorTextView : TextView
     {
         public ConcurrentDictionary<Point, ParseError> Errors { get; set; } = new ConcurrentDictionary<Point, ParseError>();
+        public ConcurrentDictionary<Point, string> ColumnErrors { get; set; } = new ConcurrentDictionary<Point, string>();
         private ParseError[] _errors;
 
         public PowerShellEditorTextView(Runspace runspace)
@@ -187,6 +188,11 @@ namespace psedit
                         m.Extent.StartColumnNumber <= (tokenCol) &&
                         m.Extent.EndColumnNumber <= (tokenCol)
                         );
+
+                    if (colError != null)
+                    {
+                        ColumnErrors.TryAdd(new Point(idxCol, idxRow), colError.Message);
+                    }
 
                     if (idxCol < line.Count && Selecting && PointInSelection(idxCol, idxRow))
                     {

--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -392,9 +392,9 @@ namespace psedit
 
         private void UpdatePosition()
         {
-            if (textEditor.Errors.ContainsKey(textEditor.CursorPosition))
+            if (textEditor.ColumnErrors.ContainsKey(textEditor.CursorPosition))
             {
-                cursorStatus.Title = textEditor.Errors[textEditor.CursorPosition].Message;
+                cursorStatus.Title = textEditor.ColumnErrors[textEditor.CursorPosition];
             }
             else
             {


### PR DESCRIPTION
partly broke this in #13 as i didnt realise we used the same errors for the status bar as the errors dialog

now we make a separate hashtable containing every column with their corresponding error message, so there's now one list for the error popup (as it needs to show unique errors) and another for the status bar

![ErrorsStatusBar](https://user-images.githubusercontent.com/18571127/221430101-0b8cea3d-a557-4337-9b94-6e65368e3245.gif)
