### PR TITLE
Fix modified flag next to saved filename

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -17,6 +17,8 @@ namespace psedit
         public ConcurrentDictionary<Point, string> ColumnErrors { get; set; } = new ConcurrentDictionary<Point, string>();
         private ParseError[] _errors;
 
+        public bool modified = false;
+
         public PowerShellEditorTextView(Runspace runspace)
         {
             Autocomplete = new PowerShellAutocomplete(runspace);
@@ -118,6 +120,10 @@ namespace psedit
 
         public override void Redraw(Rect bounds)
         {
+            if (IsDirty)
+            {
+                modified = true;
+            }
             var text = Text.ToString();
             Parser.ParseInput(text, out Token[] tokens, out ParseError[] errors);
             Errors.Clear();

--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -148,7 +148,7 @@ namespace psedit
 
             textEditor.TextChanged += () =>
             {
-                if (!fileNameStatus.Title.EndsWith("*"))
+                if (!fileNameStatus.Title.EndsWith("*") && textEditor.modified == true)
                 {
                     fileNameStatus.Title += "*";
                     statusBar.SetNeedsDisplay();
@@ -384,8 +384,8 @@ namespace psedit
                 Path = dialog.FilePath.ToString();
                 fileNameStatus.Title = Path;
             }
-
             fileNameStatus.Title = fileNameStatus.Title.TrimEnd("*");
+            textEditor.modified = false;
             statusBar.SetNeedsDisplay();
 
             try
@@ -412,8 +412,10 @@ namespace psedit
             {
                 cursorStatus.Title = string.Empty;
             }
-
-
+            if (textEditor.modified == true && !fileNameStatus.Title.EndsWith("*") && fileNameStatus.Title != "Unsaved")
+            {
+                fileNameStatus.Title += "*";
+            }
             position.Title = $"{textEditor.CursorPosition.X},{textEditor.CursorPosition.Y}";
             statusBar.SetNeedsDisplay();
         }


### PR DESCRIPTION
Currently we add * flag to path, only if you save the file

I think the behavior should be no * if you have just saved, or just opened a file, and only if you modify the content of the file should we display a *

This change adds a modified flag on the texteditor, that we update incase the user change the text

If you save, then we reset the modified flag on the texteditor, keeping it consistent with * after you modified the text, and the flag is reset on save :-)
![ModifiedStatusBar](https://user-images.githubusercontent.com/18571127/221654057-7a4cf334-7b26-4558-97f2-93884edb3fa8.gif)
