### PR TITLE
add button for creating new file

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -66,6 +66,7 @@ namespace psedit
 
             top.Add(new MenuBar(new MenuBarItem[] {
                 new MenuBarItem ("_File", new MenuItem [] {
+                        new MenuItem ("_New", "", New, shortcut: Key.CtrlMask | Key.N),
                         new MenuItem ("_Open", "", () => {
                             var dialog = new OpenDialog("Open file", "Open file");
                             dialog.CanChooseDirectories = false;
@@ -367,6 +368,13 @@ namespace psedit
             });
 
             Application.Run(dialog);
+        }
+
+        private void New()
+        {
+            fileNameStatus.Title = "Unsaved";
+            Path = null;
+            textEditor.Text = "";
         }
 
         private void Save(bool saveAs)

--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -66,7 +66,7 @@ namespace psedit
 
             top.Add(new MenuBar(new MenuBarItem[] {
                 new MenuBarItem ("_File", new MenuItem [] {
-                        new MenuItem ("_New", "", New, shortcut: Key.CtrlMask | Key.N),
+                        new MenuItem ("_New", "", New),
                         new MenuItem ("_Open", "", () => {
                             var dialog = new OpenDialog("Open file", "Open file");
                             dialog.CanChooseDirectories = false;


### PR DESCRIPTION
as described in issue #30 , we are missing a New button :-)

This adds the New button which clears texteditor and clears the referenced paths from previously opened file

note that it was not possible to use the standard shortcut for CTRL + N to create new file, Terminal.Gui does not seem to like me assigning the shortcut to it.. so I left it undefined for now