### PR TITLE
fix allowed filetypes in open/save dialogs

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -6,6 +6,7 @@ using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Text;
 using Terminal.Gui;
+using System.Collections.Generic;
 
 namespace psedit
 {
@@ -68,11 +69,12 @@ namespace psedit
                 new MenuBarItem ("_File", new MenuItem [] {
                         new MenuItem ("_New", "", New),
                         new MenuItem ("_Open", "", () => {
-                            var dialog = new OpenDialog("Open file", "Open file");
+                            List<string> allowedFileTypes = new List<string>();
+                            allowedFileTypes.Add(".ps1");
+                            var dialog = new OpenDialog("Open file", "", allowedFileTypes);
                             dialog.CanChooseDirectories = false;
                             dialog.CanChooseFiles = true;
                             dialog.AllowsMultipleSelection = false;
-                            dialog.AllowedFileTypes = new [] {".ps1"};
 
                             Application.Run(dialog);
 
@@ -381,8 +383,9 @@ namespace psedit
         {
             if (string.IsNullOrEmpty(Path) || saveAs)
             {
-                var dialog = new SaveDialog("Save file", "Save file");
-                dialog.AllowedFileTypes = new string[] { ".ps1" };
+                List<string> allowedFileTypes = new List<string>();
+                allowedFileTypes.Add(".ps1");
+                var dialog = new SaveDialog(saveAs ? "Save file as" : "Save file","", allowedFileTypes);
                 Application.Run(dialog);
 
                 if (dialog.FilePath.IsEmpty || dialog.Canceled == true || Directory.Exists(dialog.FilePath.ToString()))


### PR DESCRIPTION
This fixes #37, seems like the allowed file types that we were passing did not get applied, now it will correctly set .ps1 
![image](https://user-images.githubusercontent.com/18571127/221940983-0dfac1a1-f0a3-45d3-912c-d9b10b2dac77.png)


### Note that this PR conflicts with the PR #39, so please merge that first and then overwrite with the changes from this one :)

