### PR TITLE
Update to use Terminal.Gui 1.9.0

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -118,6 +118,11 @@ namespace psedit
 
         public List<List<Rune>> Runes { get; private set; }
 
+        private void ColorNormal()
+        {
+            // this is default color / background when there is no content
+            Driver.SetAttribute(Terminal.Gui.Attribute.Make(Color.Green, Color.Black));
+        }
         public override void Redraw(Rect bounds)
         {
             if (IsDirty)
@@ -204,21 +209,7 @@ namespace psedit
                     {
                         ColumnErrors.TryAdd(new Point(idxCol, idxRow), colError.Message);
                     }
-
-                    if (idxCol < line.Count && Selecting && PointInSelection(idxCol, idxRow))
-                    {
-                        ColorSelection(line, idxCol);
-                    }
-                    else if (idxCol == CurrentColumn && idxRow == CurrentRow && !Selecting && !Used
-                      && HasFocus && idxCol < lineRuneCount)
-                    {
-                        ColorUsed(line, idxCol);
-                    }
-                    else
-                    {
-                        ColorNormal(line, idxCol);
-                    }
-
+                    
                     if (rune == '\t')
                     {
                         cols += TabWidth + 1;

--- a/psedit.csproj
+++ b/psedit.csproj
@@ -5,9 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Nstack.Core" Version="1.0.5" />
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-      <PackageReference Include="Terminal.Gui" Version="1.7.*" />
+      <PackageReference Include="Terminal.Gui" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have updated the project to use Terminal.Gui 1.9.0 (latest version)

There is a new event available in this version which will allow us to solve #33

The only breaking thing I encountered was ColorNormal/ColorUsed/ColorSelection which were made protected virtual in a previous version (https://github.com/gui-cs/Terminal.Gui/pull/1336)

I added a method for setting the normal coloring and removed the other scenarios as we set the coloring on a per rune basis during the token matching, I did testing and I cant tell the difference with or without the code at least.. but if you have time feel free to help verify that my understanding is correct :-)

I also removed Nstack.Core from the csproj as it's a dependency of Terminal.Gui, so we let nuget restore the dependency of Terminal.Gui rather than us defining the version ourselves