### PR TITLE
Clear column errors before population

### DIFF
--- a/PowerShellEditorTextView.cs
+++ b/PowerShellEditorTextView.cs
@@ -127,6 +127,7 @@ namespace psedit
             var text = Text.ToString();
             Parser.ParseInput(text, out Token[] tokens, out ParseError[] errors);
             Errors.Clear();
+            ColumnErrors.Clear();
             _errors = errors;
             Runes = StringToRunes(text);
             foreach (var error in _errors) 


### PR DESCRIPTION
I forgot to clear the ColumnErrors before redraw, so it's currently remembering errors after you update the text