### PR TITLE
Update column / line numbers in status bar

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -62,7 +62,7 @@ namespace psedit
             top = Application.Top;
 
             var versionStatus = new StatusItem(Key.Unknown, base.MyInvocation.MyCommand.Module.Version.ToString(), () => { });
-            position = new StatusItem(Key.Unknown, "0,0", () => { });
+            position = new StatusItem(Key.Unknown, "", () => { });
             cursorStatus = new StatusItem(Key.Unknown, "", () => { });
 
             statusBar = new StatusBar(new StatusItem[] { fileNameStatus, versionStatus, position, cursorStatus });
@@ -432,7 +432,7 @@ namespace psedit
             {
                 fileNameStatus.Title += "*";
             }
-            position.Title = $"{textEditor.CursorPosition.X},{textEditor.CursorPosition.Y}";
+            position.Title = $"Ln {textEditor.CursorPosition.Y + 1}, Col {textEditor.CursorPosition.X + 1}";
             statusBar.SetNeedsDisplay();
         }
 


### PR DESCRIPTION
The column / line number is off by 1 for column and line, so we do +1 on each to get the correct values

I also changed from displaying \<column>,\<line>, to **Ln \<line>, Col \<column>**
I think this just makes it clearer and keeps it aligned with the order we show it in syntax errors too

Now they are aligned to the columns reported by the syntax errors, note that the gif below is with Terminal.Gui 1.9.0 using the correct event (hence why its updating correctly😀)

![UpdateStatusBar](https://user-images.githubusercontent.com/18571127/222544258-465d88fc-0634-4da7-89b2-3303c9cd6a5b.gif)
