### PR TITLE
Use UnwrappedCursorPosition event instead

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -40,7 +40,7 @@ namespace psedit
         protected override void ProcessRecord()
         {
             textEditor = new PowerShellEditorTextView(_runspace);
-            textEditor.KeyPress += (k) =>
+            textEditor.UnwrappedCursorPosition += (k) =>
             {
                 UpdatePosition();
             };


### PR DESCRIPTION
Fixes #33, now we use the event "UnwrappedCursorPosition" instead, so the Ln/Col is always updated when you move the cursor 

This is the approach used in Terminal.Gui's UICatalog example for Editor as well