### PR TITLE
Add workaround for CTRL+Q functionality

### DIFF
--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -58,7 +58,7 @@ namespace psedit
                 return true;
             };
 
-            fileNameStatus = new StatusItem(Key.Unknown, "Unsaved", () => { });
+            fileNameStatus = new StatusItem(Key.CtrlMask | Key.Q, "Unsaved", () => { Quit(); });
 
             if (Path != null)
             {


### PR DESCRIPTION
This PR fixes #52, we do support prompting for saving on exit, but there seem to be a bug in Terminal.Gui that can be reproduced in the UICatalog sample project too

It seems the key for CTRL+Q isnt caught when defined in the MenuBar, however.. it seems to work fine from the StatusBar

Therefore, adding in this workaround, to get it working again