### PR TITLE
Fix autocomplete for environment/global variables

### DIFF
--- a/Autocomplete/PowershellAutocomplete.cs
+++ b/Autocomplete/PowershellAutocomplete.cs
@@ -115,7 +115,7 @@ namespace psedit
         public override bool IsWordChar(Rune rune)
         {
             var c = (char)rune;
-            return Char.IsLetterOrDigit(c) || c == '$' || c == '-';
+            return Char.IsLetterOrDigit(c) || c == '$' || c == '-' || c == ':';
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
This PR fixes #55, which impacts the autocomplete of environment / global variables, as colon is not considered a word separator, but this is valid for PowerShell variables

It should now autocomplete correctly
![colon-variables](https://github.com/ironmansoftware/psedit/assets/18571127/f9665844-3bd8-4fd0-9283-e709eabd073c)
