### PR TITLE
Upgrade Terminal.Gui to 1.10.0

### DIFF
--- a/Autocomplete/PowershellAutocomplete.cs
+++ b/Autocomplete/PowershellAutocomplete.cs
@@ -45,7 +45,7 @@ namespace psedit
             }
         }
 
-        private void TryGenerateSuggestions()
+        private void TryGenerateSuggestions(int columnOffset = 0)
         {
             var host = (EditorTextView)HostControl;
             var offset = 0;
@@ -80,7 +80,7 @@ namespace psedit
             {
                 if (_suggestions != null)
                 {
-                    var word = GetCurrentWord();
+                    var word = GetCurrentWord(columnOffset);
                     if (!System.String.IsNullOrEmpty(word))
                     {
                         Suggestions = _suggestions.Where(m => m.StartsWith(word, StringComparison.OrdinalIgnoreCase)).ToList().AsReadOnly();
@@ -103,11 +103,11 @@ namespace psedit
             }
         }
 
-        public override void GenerateSuggestions()
+        public override void GenerateSuggestions(int columnOffset = 0)
         {
             try
             {
-                TryGenerateSuggestions();
+                TryGenerateSuggestions(columnOffset);
             }
             catch { }
         }
@@ -119,12 +119,12 @@ namespace psedit
         }
 
         ///<inheritdoc/>
-        protected override string GetCurrentWord()
+        protected override string GetCurrentWord(int columnOffset = 0)
         {
             var host = (TextView)HostControl;
             var currentLine = host.GetCurrentLine();
             var cursorPosition = Math.Min(host.CurrentColumn, currentLine.Count);
-            return IdxToWord(currentLine, cursorPosition);
+            return IdxToWord(currentLine, cursorPosition, columnOffset);
         }
 
         /// <inheritdoc/>

--- a/psedit.csproj
+++ b/psedit.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-      <PackageReference Include="Terminal.Gui" Version="1.9.0" />
+      <PackageReference Include="Terminal.Gui" Version="1.10.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR upgrades Terminal.Gui to 1.10 (https://github.com/gui-cs/Terminal.Gui/releases/tag/v1.10.0) which seems to be the latest version available on .NET Standard 2.0, so that's a future problem to solve..

This version of Terminal.Gui fixes the issue described in #51

There is also some improvements to the Autocomplete behavior etc. 