### PR TITLE
Update Terminal.Gui to 1.16.0, and make psedit compatible again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,12 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build
-      run: dotnet build -c Release
+    - name: Build .NET Standard 2.1
+      run: dotnet build -c Release -f netstandard2.1
+    
+    - name: Build .NET Framework 4.7.2
+      run: dotnet build -c Release -f net472
+
+    - name: List build artifacts
+      shell: pwsh
+      run: Get-ChildItem -Path .\bin\Release -Recurse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Build
-      run: dotnet publish
+      run: dotnet build -c Release

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,8 +24,11 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build
-      run: dotnet build -c Release
+    - name: Build .NET Standard 2.1
+      run: dotnet build -c Release -f netstandard2.1
+    
+    - name: Build .NET Framework 4.7.2
+      run: dotnet build -c Release -f net472
 
     - name: Release
       run: Publish-Module -Path .\bin\Release -NuGetApiKey $Env:APIKEY

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -25,10 +25,10 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Build
-      run: dotnet publish -o psedit
+      run: dotnet build -c Release
 
     - name: Release
-      run: Publish-Module -Path .\psedit -NuGetApiKey $Env:APIKEY
+      run: Publish-Module -Path .\bin\Release -NuGetApiKey $Env:APIKEY
       env:
         APIKEY: ${{ secrets.APIKEY }}
       shell: pwsh

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
                 "-Command",
                 "& { Import-Module .\\psedit.psd1; Show-PSEditor}"
             ],
-            "cwd": "${workspaceFolder}\\bin\\Debug\\netstandard2.0\\publish",
+            "cwd": "${workspaceFolder}\\bin\\Debug",
             "console": "externalTerminal",
             "stopAtEntry": false
         },
@@ -30,7 +30,7 @@
                 "-Command",
                 "& { Import-Module .\\psedit.psd1; Show-PSEditor}"
             ],
-            "cwd": "${workspaceFolder}\\bin\\Debug\\netstandard2.0\\publish",
+            "cwd": "${workspaceFolder}\\bin\\Debug",
             "console": "externalTerminal",
             "stopAtEntry": false
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "command": "dotnet",
             "type": "shell",
             "args": [
-                "publish",
+                "build",
                 // Ask dotnet build to generate full paths for file names.
                 "/property:GenerateFullPaths=true",
                 // Do not generate summary otherwise it leads to duplicate errors in Problems panel

--- a/psedit.csproj
+++ b/psedit.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <Target Name="CopyAdditionalFiles" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
-    <!-- Copy psedit.psd1 and psedit.psm1 to the root output directory -->
+    <!-- Copy psedit.psd1 to the root output directory -->
     <Copy SourceFiles="psedit.psd1"
           DestinationFolder="bin\Debug"
           SkipUnchangedFiles="true" />
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <Target Name="CopyAdditionalFilesRelease" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
-    <!-- Copy psedit.psd1 and psedit.psm1 to the root output directory -->
+    <!-- Copy psedit.psd1 to the root output directory -->
     <Copy SourceFiles="psedit.psd1"
           DestinationFolder="bin\Release"
           SkipUnchangedFiles="true" />

--- a/psedit.csproj
+++ b/psedit.csproj
@@ -1,19 +1,48 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-      <PackageReference Include="Terminal.Gui" Version="1.10.0" />
+      <PackageReference Include="Terminal.Gui" Version="1.16.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="psedit.psd1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  <!-- Output paths for Debug configuration -->
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Debug|netstandard2.1'">
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputPath>bin\Debug\coreclr\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Debug|net472'">
+    <OutputPath>bin\Debug\clr\</OutputPath>
+  </PropertyGroup>
+
+  <Target Name="CopyAdditionalFiles" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+    <!-- Copy psedit.psd1 and psedit.psm1 to the root output directory -->
+    <Copy SourceFiles="psedit.psd1"
+          DestinationFolder="bin\Debug"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Output paths for Release configuration -->
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|netstandard2.1'">
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputPath>bin\Release\coreclr\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net472'">
+    <OutputPath>bin\Release\clr\</OutputPath>
+  </PropertyGroup>
+
+  <Target Name="CopyAdditionalFilesRelease" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <!-- Copy psedit.psd1 and psedit.psm1 to the root output directory -->
+    <Copy SourceFiles="psedit.psd1"
+          DestinationFolder="bin\Release"
+          SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/psedit.psd1
+++ b/psedit.psd1
@@ -9,8 +9,14 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule      = 'psedit.dll'
-
+    RootModule = if($PSEdition -eq 'Core')
+    {
+        'coreclr\psedit.dll'
+    }
+    else # Desktop
+    {
+        'clr\psedit.dll'
+    }
     # Version number of this module.
     ModuleVersion   = '0.0.6'
 


### PR DESCRIPTION
Updated Terminal.Gui reference to 1.16.0, as we were previously locked on 1.10.0 due to dropped support for .NET Standard 2.0 in Terminal.Gui

In order to solve this, we now multi-target .NET Standard 2.1 & .NET Framework 4.7.2

This is a solution suggested [here](https://learn.microsoft.com/en-us/powershell/gallery/concepts/module-psedition-support?view=powershellget-3.x#option-2-use-psedition-variable-in-the-psd1-file-to-load-the-proper-dlls), and is the same approach used in PSScriptAnalyzer etc.

The psd1 file will now evaluate if its running under Core (and then load the .NET Standard 2.1 dll) and if not, then we fallback to a .NET Framework 4.7.2 based build of psedit.

Module folder now looks like this:

     coreclr (.NET Standard 2.1 build)
     clr (.NET Framework 4.7.1 build)
     psedit.psd1

I also updated the following
* Updated vscode launch/tasks json files, and confirmed launching/debugging still works
* Updated yml workflows for GitHub, as dotnet publish is no longer supported. We must use dotnet build as publish is not supported for projects that multi targets.