### PR TITLE
#64 upgrade to terminal gui 1.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,5 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build .NET Standard 2.1
-      run: dotnet build -c Release -f netstandard2.1
-    
-    - name: Build .NET Framework 4.7.2
-      run: dotnet build -c Release -f net472
-
-    - name: List build artifacts
-      shell: pwsh
-      run: Get-ChildItem -Path .\bin\Release -Recurse
+    - name: Build
+      run: dotnet publish

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,16 +24,13 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build .NET Standard 2.1
-      run: dotnet build -c Release -f netstandard2.1
-    
-    - name: Build .NET Framework 4.7.2
-      run: dotnet build -c Release -f net472
+    - name: Build
+      run: dotnet publish -o psedit
 
     - name: Release
       run: |
         Install-Module Microsoft.PowerShell.PSResourceGet -Scope CurrentUser -Force
-        Publish-PSResource -Path .\bin\Release -ApiKey $Env:APIKEY
+        Publish-PSResource -Path .\psedit -ApiKey $Env:APIKEY
       env:
         APIKEY: ${{ secrets.APIKEY }}
       shell: pwsh

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
                 "-Command",
                 "& { Import-Module .\\psedit.psd1; Show-PSEditor}"
             ],
-            "cwd": "${workspaceFolder}\\bin\\Debug",
+            "cwd": "${workspaceFolder}\\bin\\Debug\\netstandard2.0\\publish",
             "console": "externalTerminal",
             "stopAtEntry": false
         },
@@ -30,7 +30,7 @@
                 "-Command",
                 "& { Import-Module .\\psedit.psd1; Show-PSEditor}"
             ],
-            "cwd": "${workspaceFolder}\\bin\\Debug",
+            "cwd": "${workspaceFolder}\\bin\\Debug\\netstandard2.0\\publish",
             "console": "externalTerminal",
             "stopAtEntry": false
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "command": "dotnet",
             "type": "shell",
             "args": [
-                "build",
+                "publish",
                 // Ask dotnet build to generate full paths for file names.
                 "/property:GenerateFullPaths=true",
                 // Do not generate summary otherwise it leads to duplicate errors in Problems panel

--- a/psedit.csproj
+++ b/psedit.csproj
@@ -1,48 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-      <PackageReference Include="Terminal.Gui" Version="1.16.0" />
+      <PackageReference Include="Terminal.Gui" Version="1.17.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <!-- Output paths for Debug configuration -->
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Debug|netstandard2.1'">
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OutputPath>bin\Debug\coreclr\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Debug|net472'">
-    <OutputPath>bin\Debug\clr\</OutputPath>
-  </PropertyGroup>
-
-  <Target Name="CopyAdditionalFiles" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
-    <!-- Copy psedit.psd1 to the root output directory -->
-    <Copy SourceFiles="psedit.psd1"
-          DestinationFolder="bin\Debug"
-          SkipUnchangedFiles="true" />
-  </Target>
-
-  <!-- Output paths for Release configuration -->
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|netstandard2.1'">
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OutputPath>bin\Release\coreclr\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net472'">
-    <OutputPath>bin\Release\clr\</OutputPath>
-  </PropertyGroup>
-
-  <Target Name="CopyAdditionalFilesRelease" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
-    <!-- Copy psedit.psd1 to the root output directory -->
-    <Copy SourceFiles="psedit.psd1"
-          DestinationFolder="bin\Release"
-          SkipUnchangedFiles="true" />
-  </Target>
+  <ItemGroup>
+    <None Include="psedit.psd1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/psedit.psd1
+++ b/psedit.psd1
@@ -9,14 +9,7 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule = if($PSEdition -eq 'Core')
-    {
-        'coreclr\psedit.dll'
-    }
-    else # Desktop
-    {
-        'clr\psedit.dll'
-    }
+    RootModule      = 'psedit.dll'
     # Version number of this module.
     ModuleVersion   = '0.0.7'
 


### PR DESCRIPTION
This PR upgrades Terminal.Gui to 1.17.1 which is supported on  .NET Standard 2.0, so we dont need to have a .net standard 2.1 / .net framework split build anymore

fixes #64 