### PR TITLE
Yaml improvements: set editor language when opening yaml, improve syntax highlighting

### DIFF
--- a/EditorContext/YamlEditorContext.cs
+++ b/EditorContext/YamlEditorContext.cs
@@ -37,7 +37,9 @@ namespace psedit
                     }
                     return theme.GetColor("String");
                 case SequenceStart _:
+                    return theme.GetColor("Secondary");
                 case SequenceEnd _:
+                    return theme.GetColor("Secondary");
                 case MappingStart _:
                 case MappingEnd _:
                     return theme.GetColor("Accent");
@@ -66,8 +68,8 @@ namespace psedit
                         break;
                     }
                     var token = parser.Current;
-                    // skip zero-length tokens
-                    if (parser.Current.Start == parser.Current.End)
+                    // skip tokens that dont have a position
+                    if (token is StreamStart or StreamEnd or DocumentStart or DocumentEnd or MappingStart or MappingEnd)
                     {
                         continue;
                     }

--- a/EditorContext/YamlEditorContext.cs
+++ b/EditorContext/YamlEditorContext.cs
@@ -37,9 +37,9 @@ namespace psedit
                     }
                     return theme.GetColor("String");
                 case SequenceStart _:
-                    return theme.GetColor("Secondary");
+                    return theme.GetColor("Warning");
                 case SequenceEnd _:
-                    return theme.GetColor("Secondary");
+                    return theme.GetColor("Warning");
                 case MappingStart _:
                 case MappingEnd _:
                     return theme.GetColor("Accent");
@@ -83,6 +83,7 @@ namespace psedit
                     var endIndex = parser.Current != null ? (int)parser.Current.End.Column : oldPos + 1;
                     var color = GetColor(token);
                     var result = new ParseResult { StartIndex = startIndex, EndIndex = endIndex, Color = color, LineNumber = lineNumber };
+                    Debug.WriteLine($"YAML Token: {token} Line: {lineNumber} StartIndex: {startIndex} EndIndex: {endIndex} Color: {color}");
                     resultList.Add(result);
                     oldPos = endIndex;
                 }

--- a/EditorContext/YamlEditorContext.cs
+++ b/EditorContext/YamlEditorContext.cs
@@ -31,6 +31,10 @@ namespace psedit
                 case DocumentEnd _:
                     return theme.GetColor("Warning");
                 case Scalar scalar:
+                    if (scalar.IsKey)
+                    {
+                        return theme.GetColor("Info");
+                    }
                     return theme.GetColor("String");
                 case SequenceStart _:
                 case SequenceEnd _:
@@ -62,6 +66,11 @@ namespace psedit
                         break;
                     }
                     var token = parser.Current;
+                    // skip zero-length tokens
+                    if (parser.Current.Start == parser.Current.End)
+                    {
+                        continue;
+                    }
                     var lineNumber = parser.Current != null ? (int)parser.Current.Start.Line : oldLine + 1;
                     if (oldLine != lineNumber)
                     {
@@ -69,7 +78,7 @@ namespace psedit
                         oldPos = 1;
                     }
                     var startIndex = oldPos;
-                    var endIndex = parser.Current != null ? (int)parser.Current.Start.Column : oldPos + 1;
+                    var endIndex = parser.Current != null ? (int)parser.Current.End.Column : oldPos + 1;
                     var color = GetColor(token);
                     var result = new ParseResult { StartIndex = startIndex, EndIndex = endIndex, Color = color, LineNumber = lineNumber };
                     resultList.Add(result);

--- a/EditorContext/YamlEditorContext.cs
+++ b/EditorContext/YamlEditorContext.cs
@@ -69,7 +69,7 @@ namespace psedit
                     }
                     var token = parser.Current;
                     // skip tokens that dont have a position
-                    if (token is StreamStart or StreamEnd or DocumentStart or DocumentEnd or MappingStart or MappingEnd)
+                    if (token is StreamStart or StreamEnd or DocumentStart or DocumentEnd or MappingStart or MappingEnd or SequenceStart or SequenceEnd)
                     {
                         continue;
                     }
@@ -79,8 +79,8 @@ namespace psedit
                         oldLine = lineNumber;
                         oldPos = 1;
                     }
-                    var startIndex = oldPos;
-                    var endIndex = parser.Current != null ? (int)parser.Current.End.Column : oldPos + 1;
+                    var startIndex = parser.Current != null ? (int)parser.Current.Start.Column : oldPos + 1;
+                    var endIndex = parser.Current != null ? (int)parser.Current.End.Column -1 : oldPos + 1;
                     var color = GetColor(token);
                     var result = new ParseResult { StartIndex = startIndex, EndIndex = endIndex, Color = color, LineNumber = lineNumber };
                     Debug.WriteLine($"YAML Token: {token} Line: {lineNumber} StartIndex: {startIndex} EndIndex: {endIndex} Color: {color}");

--- a/ShowEditorCommand.cs
+++ b/ShowEditorCommand.cs
@@ -246,6 +246,9 @@ namespace psedit
                 case ".txt":
                     textEditor.SetLanguage(LanguageEnum.Text);
                     break;
+                case ".yml": case ".yaml":
+                    textEditor.SetLanguage(LanguageEnum.YAML);
+                    break;
                 default:
                     textEditor.SetLanguage(LanguageEnum.Text);
                     break;


### PR DESCRIPTION
* Set editor language to YAML when opening yml/yaml files, fixes yml files being treated as text when opening them from Load or via -Path argument

* fix some of the token matching for yaml
its not perfect, but get the colors more correct, there are still some corner cases to improve, all tokens should be properly colored, but the blocks etc are not being colored at the moment, seems pretty tricky getting this correct

before:
<img width="668" height="502" alt="image" src="https://github.com/user-attachments/assets/4fb5fc23-9aab-4bf7-8a0f-d41335d4afd9" />


after:
<img width="727" height="538" alt="image" src="https://github.com/user-attachments/assets/a3c7777f-c366-4c60-9be7-5032a8d4da7e" />
