### PR TITLE
Fix syntax highlighting when changing height of Terminal

### DIFF
--- a/EditorContext/EditorContext.cs
+++ b/EditorContext/EditorContext.cs
@@ -9,6 +9,7 @@ namespace psedit
     {
         public string _originalText;
         public int _lastParseTopRow;
+        public int _lastParseHeight;
         public int _lastParseRightColumn;
         public int _tabWidth;
         public bool CanFormat = false;

--- a/EditorContext/JSONEditorContext.cs
+++ b/EditorContext/JSONEditorContext.cs
@@ -126,7 +126,7 @@ namespace psedit
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
             // quick exit when text is the same and the top row / right col has not changed
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && height == _lastParseHeight)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && _lastParseHeight == height)
             {
                 return;
             }

--- a/EditorContext/JSONEditorContext.cs
+++ b/EditorContext/JSONEditorContext.cs
@@ -126,7 +126,7 @@ namespace psedit
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
             // quick exit when text is the same and the top row / right col has not changed
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && height == _lastParseHeight)
             {
                 return;
             }
@@ -144,6 +144,7 @@ namespace psedit
             int bottom = topRow + height;
             _originalText = text;
             _lastParseTopRow = topRow;
+            _lastParseHeight = height;
             _lastParseRightColumn = right;
             long count = 0;
             var row = 0;

--- a/EditorContext/MarkdownEditorContext.cs
+++ b/EditorContext/MarkdownEditorContext.cs
@@ -184,7 +184,7 @@ namespace psedit
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
             // Quick exit when text is the same and the top row / right col has not changed
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && _lastParseHeight == height)
             {
                 return;
             }
@@ -202,6 +202,7 @@ namespace psedit
             int bottom = topRow + height;
             _originalText = text;
             _lastParseTopRow = topRow;
+            _lastParseHeight = height;
             _lastParseRightColumn = right;
             var row = 0;
 

--- a/EditorContext/PowerShellEditorContext.cs
+++ b/EditorContext/PowerShellEditorContext.cs
@@ -197,7 +197,7 @@ namespace psedit
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
             // quick exit when text is the same and the top row / right col has not changed
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && _lastParseHeight == height)
             {
                 return;
             }
@@ -217,6 +217,7 @@ namespace psedit
             int bottom = topRow + height;
             _originalText = text;
             _lastParseTopRow = topRow;
+            _lastParseHeight = height;
             _lastParseRightColumn = right;
             var row = 0;
             for (int idxRow = topRow; idxRow < Runes.Count; idxRow++)

--- a/EditorContext/XmlEditorContext.cs
+++ b/EditorContext/XmlEditorContext.cs
@@ -391,7 +391,7 @@ namespace psedit
 
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && _lastParseHeight == height)
             {
                 return;
             }
@@ -408,6 +408,7 @@ namespace psedit
             int bottom = topRow + height;
             _originalText = text;
             _lastParseTopRow = topRow;
+            _lastParseHeight = height;
             _lastParseRightColumn = right;
 
             var row = 0;

--- a/EditorContext/YamlEditorContext.cs
+++ b/EditorContext/YamlEditorContext.cs
@@ -115,7 +115,7 @@ namespace psedit
         }
         public override void ParseText(int height, int topRow, int left, int right, string text, List<List<Rune>> Runes)
         {
-            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn)
+            if (_originalText == text && topRow == _lastParseTopRow && right == _lastParseRightColumn && _lastParseHeight == height)
             {
                 return;
             }
@@ -130,6 +130,7 @@ namespace psedit
             int bottom = topRow + height;
             _originalText = text;
             _lastParseTopRow = topRow;
+            _lastParseHeight = height;
             _lastParseRightColumn = right;
             long count = 0;
             var row = 0;


### PR DESCRIPTION
When changing the height of the Terminal, the editor context did not recalculate the color coding, and rending with default color

We now set the height on the editor context, and force a recalculate when its changed