### PR TITLE
exclude BOM from parsing if present in markdown file

### DIFF
--- a/EditorContext/MarkdownEditorContext.cs
+++ b/EditorContext/MarkdownEditorContext.cs
@@ -28,6 +28,7 @@ namespace psedit
                 for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
                 {
                     var line = lines[lineIndex];
+                    line = line.TrimStart('\uFEFF');
                     int lineNumber = lineIndex + 1;
                     
                     // Check for code block delimiters (```)


### PR DESCRIPTION
parsing was not working correctly on first line if file was saved with BOM